### PR TITLE
moved import from matplotlib down inside _write for #27

### DIFF
--- a/voropy/smoothing.py
+++ b/voropy/smoothing.py
@@ -2,7 +2,6 @@
 #
 from __future__ import print_function
 
-from matplotlib import pyplot as plt
 import numpy
 
 from .mesh_tri import MeshTri
@@ -174,6 +173,7 @@ def _print_stats(data_list):
 
 
 def _write(mesh, filetype, k):
+    from matplotlib import pyplot as plt
     if filetype == 'png':
         fig = mesh.plot(
             show_coedges=False,


### PR DESCRIPTION
 following 4be52d1095f5ea1089e5e8da2563b5c242bbd2e0 ‘make matplotlib dependency optional’, import voropy raises
```
ModuleNotFoundError: No module named 'matplotlib'
```

This affects pygmsh too which imports voropy.

I think this is the right fix, as already in mesh_{tri,tetra}.py in the same directory.